### PR TITLE
Added modifiers as objects instead of numbers

### DIFF
--- a/src/main/java/de/schottky/core/UpgradableArmor.java
+++ b/src/main/java/de/schottky/core/UpgradableArmor.java
@@ -1,6 +1,7 @@
 package de.schottky.core;
 
 import com.google.gson.JsonObject;
+import de.schottky.expression.Modifier;
 import de.schottky.util.AttributeUtil;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
@@ -56,24 +57,24 @@ public class UpgradableArmor extends UpgradableItem {
         return armor == null ? OptionalDouble.empty() : OptionalDouble.of(armor.defaultArmorToughness);
     }
 
-    public static void increaseAttributesOf(@NotNull ItemStack stack, double armorValue, double armorToughness) {
+    public static void increaseAttributesOf(@NotNull ItemStack stack, Modifier armorValue, Modifier armorToughness, int level) {
         final UpgradableArmor armor = ALL_ARMAMENTS.get(stack.getType());
         if (armor == null) return;
-        armor.increaseAttributes(stack, armorValue, armorToughness);
+        armor.increaseAttributes(stack, armorValue, armorToughness, level);
     }
 
-    public void increaseAttributes(@NotNull ItemStack stack, double armor, double armorToughness) {
-        AttributeUtil.increaseAttribute(stack, Attribute.GENERIC_ARMOR, armor, new AttributeModifier(
+    public void increaseAttributes(@NotNull ItemStack stack, Modifier armor, Modifier armorToughness, int level) {
+        AttributeUtil.increaseAttribute(stack, Attribute.GENERIC_ARMOR, armor, level, new AttributeModifier(
                 UUID.fromString("CB3F55D3-645C-4F38-A497-9C13A33DB5CF"),
                 "Armor modifier",
-                this.defaultArmor + armor,
+                armor.next(this.defaultArmor, level),
                 AttributeModifier.Operation.ADD_NUMBER,
                 this.slot));
 
-        AttributeUtil.increaseAttribute(stack, Attribute.GENERIC_ARMOR_TOUGHNESS, armorToughness, new AttributeModifier(
+        AttributeUtil.increaseAttribute(stack, Attribute.GENERIC_ARMOR_TOUGHNESS, armorToughness, level, new AttributeModifier(
                 UUID.fromString("FA233E1C-4180-4865-B01B-BCCE9785ACA3"),
                 "Armor toughness",
-                this.defaultArmorToughness + armorToughness,
+                armorToughness.next(this.defaultArmorToughness, level),
                 AttributeModifier.Operation.ADD_NUMBER,
                 this.slot));
     }

--- a/src/main/java/de/schottky/core/UpgradableMeleeWeapon.java
+++ b/src/main/java/de/schottky/core/UpgradableMeleeWeapon.java
@@ -1,6 +1,7 @@
 package de.schottky.core;
 
 import com.google.gson.JsonObject;
+import de.schottky.expression.Modifier;
 import de.schottky.util.AttributeUtil;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
@@ -38,10 +39,10 @@ public class UpgradableMeleeWeapon extends UpgradableItem {
                 object.get("attackSpeed").getAsDouble());
     }
 
-    public static void increaseAttributesOf(@NotNull ItemStack stack, double damage, double attackSpeed) {
+    public static void increaseAttributesOf(@NotNull ItemStack stack, Modifier damage, Modifier attackSpeed, int level) {
         final UpgradableMeleeWeapon weapon = ALL_WEAPONS.get(stack.getType());
         if (weapon == null) return;
-        weapon.increaseAttributes(stack, damage, attackSpeed);
+        weapon.increaseAttributes(stack, damage, attackSpeed, level);
     }
 
     public static OptionalDouble defaultDamage(Material material) {
@@ -54,18 +55,18 @@ public class UpgradableMeleeWeapon extends UpgradableItem {
         return weapon == null ? OptionalDouble.empty() : OptionalDouble.of(weapon.attackSpeed);
     }
 
-    private void increaseAttributes(@NotNull ItemStack stack, double damage, double attackSpeed) {
-        AttributeUtil.increaseAttribute(stack, Attribute.GENERIC_ATTACK_DAMAGE, damage, new AttributeModifier(
+    private void increaseAttributes(@NotNull ItemStack stack, Modifier damage, Modifier attackSpeed, int level) {
+        AttributeUtil.increaseAttribute(stack, Attribute.GENERIC_ATTACK_DAMAGE, damage, level, new AttributeModifier(
                 UUID.fromString("CB3F55D3-645C-4F38-A497-9C13A33DB5CF"),
                 "Weapon modifier",
-                this.attackDamage + damage,
+                damage.next(this.attackDamage, level),
                 AttributeModifier.Operation.ADD_NUMBER,
                 EquipmentSlot.HAND));
 
-        AttributeUtil.increaseAttribute(stack, Attribute.GENERIC_ATTACK_SPEED, attackSpeed, new AttributeModifier(
+        AttributeUtil.increaseAttribute(stack, Attribute.GENERIC_ATTACK_SPEED, attackSpeed, level, new AttributeModifier(
                 UUID.fromString("FA233E1C-4180-4865-B01B-BCCE9785ACA3"),
                 "Weapon modifier",
-                this.attackSpeed + attackSpeed,
+                attackSpeed.next(this.attackSpeed, level),
                 AttributeModifier.Operation.ADD_NUMBER,
                 EquipmentSlot.HAND));
     }

--- a/src/main/java/de/schottky/core/UpgradableRangedWeapon.java
+++ b/src/main/java/de/schottky/core/UpgradableRangedWeapon.java
@@ -2,6 +2,7 @@ package de.schottky.core;
 
 import com.github.schottky.zener.util.item.ItemStorage;
 import com.google.gson.JsonObject;
+import de.schottky.expression.Modifier;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -37,12 +38,13 @@ public class UpgradableRangedWeapon extends UpgradableItem {
 
     public static void increaseAttributes(
             @NotNull ItemStack itemStack,
-            double damage
+            Modifier modifier,
+            int level
     ) {
         final var meta = itemStack.getItemMeta();
         if (meta == null) return;
         final var previousValue = ItemStorage.getDouble(meta, DAMAGE_KEY, 0);
-        final var newValue = previousValue + damage;
+        final var newValue = modifier.next(previousValue, level);
         ItemStorage.set(meta, newValue, DAMAGE_KEY);
         itemStack.setItemMeta(meta);
     }

--- a/src/main/java/de/schottky/exception/InvalidConfiguration.java
+++ b/src/main/java/de/schottky/exception/InvalidConfiguration.java
@@ -1,5 +1,6 @@
 package de.schottky.exception;
 
+import de.schottky.expression.ExpressionParseException;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -8,6 +9,11 @@ public class InvalidConfiguration extends Exception {
     @Contract("_ -> new")
     public static @NotNull InvalidConfiguration required(String requiredValue) {
         return new InvalidConfiguration("Configuration must contain " + requiredValue + " but it's not present!");
+    }
+
+    @Contract("_, _ -> new")
+    public static @NotNull InvalidConfiguration parsingFailed(@NotNull ExpressionParseException e, String name) {
+        return new InvalidConfiguration("Cannot parse " + name + ": " + e.getMessage());
     }
 
     public InvalidConfiguration(String message) {

--- a/src/main/java/de/schottky/expression/Expression.java
+++ b/src/main/java/de/schottky/expression/Expression.java
@@ -1,0 +1,168 @@
+package de.schottky.expression;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public record Expression(Node root) {
+
+    double evaluate(double input, int level) {
+        return root.evaluate(input, level);
+    }
+
+    public Expression simplify() {
+        if (root instanceof Node.Operation operation) {
+            return operation.foldConstants().map(Expression::new).orElse(this);
+        } else {
+            return this;
+        }
+    }
+
+    interface Node {
+
+        @Contract("_, _, _ -> new")
+        static @NotNull Node operation(Operation.Type type, double left, double right) {
+            return new Operation(type, new Literal(left), new Literal(right));
+        }
+
+        double evaluate(double previous, int level);
+
+        default Node formOperationLeft(Operation.Type type, Node right) {
+            return new Operation(type, this, right);
+        }
+
+        record Literal(double value) implements Node {
+            @Override
+            public double evaluate(double previous, int level) {
+                return value;
+            }
+        }
+
+        record Variable(Kind kind) implements Node {
+            @Override
+            public double evaluate(double previous, int level) {
+                return switch (kind) {
+                    case LEVEL -> level;
+                    case PREVIOUS -> previous;
+                };
+            }
+
+            enum Kind {
+                LEVEL, PREVIOUS,
+            }
+        }
+
+        class Operation implements Node {
+
+            private Node left;
+            private Node right;
+            private final Type type;
+
+            public Operation(Type type, Node left, Node right) {
+                this.left = left;
+                this.right = right;
+                this.type = type;
+            }
+
+            public double evaluate(double previous, int level) {
+                final double leftValue = left.evaluate(previous, level);
+                final double rightValue = right.evaluate(previous, level);
+                return type.apply(leftValue, rightValue);
+            }
+
+            public Optional<Node> foldConstants() {
+                if (
+                        left instanceof Literal literalLeft &&
+                        right instanceof Literal literalRight
+                ) {
+                    var result = type.apply(literalLeft.value(), literalRight.value());
+                    return Optional.of(new Literal(result));
+                } else {
+                    var leftFolded = foldConstantsChild(left);
+                    var rightFolded = foldConstantsChild(right);
+                    if (leftFolded != null) {
+                        this.left = leftFolded;
+                    }
+                    if (rightFolded != null) {
+                        this.right = rightFolded;
+                    }
+                    if (leftFolded != null && rightFolded != null) {
+                        this.foldConstants();
+                    }
+                    if (leftFolded != null || rightFolded != null) {
+                        return foldConstants();
+                    }
+                    return Optional.empty();
+                }
+            }
+
+            private @Nullable Node foldConstantsChild(Node child) {
+                if (child instanceof Operation operation) {
+                    return operation.foldConstants().orElse(null);
+                } else {
+                    return null;
+                }
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                Operation operation = (Operation) o;
+                return left.equals(operation.left) && right.equals(operation.right) && type == operation.type;
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(left, right, type);
+            }
+
+            @Override
+            public String toString() {
+                return "Operation[" +
+                        "left=" + left +
+                        ", right=" + right +
+                        ", type=" + type +
+                        ']';
+            }
+
+            enum Type {
+                ADDITION {
+                    @Override
+                    double apply(double left, double right) {
+                        return left + right;
+                    }
+                },
+                MULTIPLICATION {
+                    @Override
+                    double apply(double left, double right) {
+                        return left * right;
+                    }
+                },
+                DIVISION {
+                    @Override
+                    double apply(double left, double right) {
+                        return left / right;
+                    }
+                },
+                MODULUS {
+                    @Override
+                    double apply(double left, double right) {
+                        return left % right;
+                    }
+                },
+                SUBTRACTION {
+                    @Override
+                    double apply(double left, double right) {
+                        return left - right;
+                    }
+                };
+
+                abstract double apply(double left, double right);
+            }
+        }
+    }
+}

--- a/src/main/java/de/schottky/expression/ExpressionLexer.java
+++ b/src/main/java/de/schottky/expression/ExpressionLexer.java
@@ -1,0 +1,135 @@
+package de.schottky.expression;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+public class ExpressionLexer implements Iterator<ExpressionLexer.Token> {
+
+    private final char[] chars;
+    private int index = 0;
+
+    public ExpressionLexer(@NotNull final String stringToParse) {
+        this.chars = stringToParse.toCharArray();
+        this.skipWhitespaces();
+    }
+
+    public String substringForToken(@NotNull Token token) {
+        return String.valueOf(chars, token.startIndex(), token.length());
+    }
+
+    @Contract(pure = true)
+    static @NotNull Iterable<Token> iterateTokensIn(@NotNull final String stringToParse) {
+        return () -> new ExpressionLexer(stringToParse);
+    }
+
+    @Override
+    public boolean hasNext() {
+        skipWhitespaces();
+        return index < chars.length;
+    }
+
+    @Override
+    public Token next() {
+        skipWhitespaces();
+        var ch = Character.toLowerCase(currentChar());
+        var startIndex = index;
+        Symbol symbol;
+        if (Character.isAlphabetic(ch)) {
+            symbol = readVariable();
+        } else if (Character.isDigit(ch) || ch == '.') {
+            symbol = readLiteral();
+        } else {
+            symbol = switch (ch) {
+                case '+' -> Symbol.PLUS;
+                case '-' -> Symbol.MINUS;
+                case '*' -> Symbol.MULTIPLY;
+                case '/' -> Symbol.DIVIDE;
+                case '%' -> Symbol.MOD;
+                case '(' -> Symbol.OPEN_PAREN;
+                case ')' -> Symbol.CLOSED_PAREN;
+                case '[' -> Symbol.OPEN_BRACKET;
+                case ']' -> Symbol.CLOSED_BRACKET;
+                case ',' -> Symbol.COMMA;
+                default -> readUnknown();
+            };
+            if (symbol != Symbol.UNKNOWN) {
+                index += 1;
+            }
+        }
+        return new Token(symbol, startIndex, index - startIndex);
+    }
+
+    private void skipWhitespaces() {
+        readWhile(Character::isWhitespace);
+    }
+
+    private @NotNull Symbol readVariable() {
+        readWhile(Character::isAlphabetic);
+        return Symbol.VARIABLE;
+    }
+
+    private @NotNull Symbol readLiteral() {
+        readWhile((ch) ->
+                Character.isDigit(ch)
+                        || ch == '.'
+        );
+        return Symbol.LITERAL;
+    }
+
+    private @NotNull Symbol readUnknown() {
+        readWhile(Predicate.not(Character::isWhitespace));
+        return Symbol.UNKNOWN;
+    }
+
+    private void readWhile(@NotNull Predicate<Character> predicate) {
+        while (predicate.test(currentChar()) && currentChar() != Character.MIN_VALUE) {
+            index += 1;
+        }
+    }
+
+    private char currentChar() {
+        if (index < chars.length) {
+            return chars[index];
+        } else {
+            return Character.MIN_VALUE;
+        }
+    }
+
+    static record Token(Symbol symbol, int startIndex, int length) {}
+
+    enum Symbol {
+        PLUS,
+        MINUS,
+        MULTIPLY,
+        DIVIDE,
+        MOD,
+        OPEN_PAREN,
+        CLOSED_PAREN,
+        OPEN_BRACKET,
+        CLOSED_BRACKET,
+        VARIABLE,
+        LITERAL,
+        COMMA,
+        UNKNOWN;
+
+        @Contract("_, _ -> new")
+        ExpressionLexer.@NotNull Token toToken(int start, int length) {
+            return new ExpressionLexer.Token(this, start, length);
+        }
+
+        public boolean isSign() {
+            return this == PLUS || this == MINUS;
+        }
+
+        public boolean isMultiplicative() {
+            return this == MULTIPLY || this == DIVIDE || this == MOD;
+        }
+
+        public boolean isAddingOperator() {
+            return this == PLUS || this == MINUS;
+        }
+    }
+}

--- a/src/main/java/de/schottky/expression/ExpressionParseException.java
+++ b/src/main/java/de/schottky/expression/ExpressionParseException.java
@@ -1,0 +1,12 @@
+package de.schottky.expression;
+
+public class ExpressionParseException extends Exception {
+
+    public ExpressionParseException(String message) {
+        super(message);
+    }
+
+    public ExpressionParseException(NumberFormatException e) {
+        super(e);
+    }
+}

--- a/src/main/java/de/schottky/expression/ExpressionParser.java
+++ b/src/main/java/de/schottky/expression/ExpressionParser.java
@@ -1,0 +1,164 @@
+package de.schottky.expression;
+
+import com.google.common.primitives.Doubles;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import de.schottky.expression.ExpressionLexer.Token;
+import de.schottky.expression.ExpressionLexer.Symbol;
+
+public class ExpressionParser {
+
+    private final ExpressionLexer tokens;
+    private Token current;
+
+    @Contract(pure = true)
+    public ExpressionParser(@NotNull String stringToParse) {
+        this.tokens = new ExpressionLexer(stringToParse);
+    }
+
+    public Modifier parse() throws ExpressionParseException {
+        if (!tokens.hasNext()) {
+            throw new ExpressionParseException("empty expression");
+        }
+        current = tokens.next();
+        return current.symbol() == Symbol.OPEN_BRACKET ?
+                parseEnumeration() :
+                parseExpression();
+    }
+
+    public Modifier parseEnumeration() throws ExpressionParseException {
+        var literals = new ArrayList<Double>();
+        while (tokens.hasNext()) {
+            var next = tokens.next();
+            if (next.symbol() == Symbol.LITERAL) {
+                literals.add(getLiteral(next));
+            } else if (next.symbol() == Symbol.CLOSED_BRACKET) {
+                break;
+            } else {
+                throw new ExpressionParseException("There can only be numbers inside the enumerations");
+            }
+        }
+        var doubles = Doubles.toArray(literals);
+        return new Modifier.Enumeration(doubles);
+    }
+
+    private @NotNull Modifier parseExpression() throws ExpressionParseException {
+        var root = simpleExpression();
+        var expression = new Expression(root);
+        var modifier = new Modifier.Calculated(expression);
+        return modifier.simplifyToSimpleModifier().orElse(modifier);
+    }
+
+    private Expression.Node simpleExpression() throws ExpressionParseException {
+        Symbol sign = null;
+        if (current.symbol().isSign()) {
+            sign = current.symbol();
+            nextSymbol(true);
+        }
+        var term = term();
+        if (sign != null) {
+            var helper = sign == Symbol.MINUS ?
+                    new Expression.Node.Literal(-1) :
+                    new Expression.Node.Literal(+1);
+            term = helper.formOperationLeft(Expression.Node.Operation.Type.MULTIPLICATION, term);
+        }
+        while (current != null && current.symbol().isAddingOperator()) {
+            var operator = switch (current.symbol()) {
+                case PLUS -> Expression.Node.Operation.Type.ADDITION;
+                case MINUS -> Expression.Node.Operation.Type.SUBTRACTION;
+                default -> throw new ExpressionParseException(
+                        "Expected an adding operator but found " + current.symbol().name().toLowerCase()
+                );
+            };
+            nextSymbol(true);
+            var right = term();
+            term = term.formOperationLeft(operator, right);
+        }
+        return term;
+    }
+
+    private Expression.@NotNull Node term() throws ExpressionParseException {
+        var factor = factor();
+        while (current != null && current.symbol().isMultiplicative()) {
+            var operator = switch (current.symbol()) {
+                case MULTIPLY -> Expression.Node.Operation.Type.MULTIPLICATION;
+                case DIVIDE -> Expression.Node.Operation.Type.DIVISION;
+                case MOD -> Expression.Node.Operation.Type.MODULUS;
+                default -> throw new ExpressionParseException(
+                        "Expected a multiplying operator but found " + current.symbol().name().toLowerCase()
+                );
+            };
+            nextSymbol(true);
+            var right = factor();
+            factor = factor.formOperationLeft(operator, right);
+        }
+        return factor;
+    }
+
+    @Contract(" -> new")
+    private Expression.@NotNull Node factor() throws ExpressionParseException {
+        return primary();
+    }
+
+    private Expression.Node primary() throws ExpressionParseException {
+        if (current.symbol() == Symbol.LITERAL) {
+            var literal = getLiteral(current);
+            nextSymbol(false);
+            return new Expression.Node.Literal(literal);
+        } else if (current.symbol() == Symbol.VARIABLE) {
+            var variable = tokens.substringForToken(current);
+            var kind = switch (variable.toLowerCase()) {
+                case "lvl", "level" ->
+                        Expression.Node.Variable.Kind.LEVEL;
+                case "prev", "previous" ->
+                        Expression.Node.Variable.Kind.PREVIOUS;
+                default -> throw new ExpressionParseException("Unrecognized variable name: " + variable);
+            };
+            nextSymbol(false);
+            return new Expression.Node.Variable(kind);
+        } else if (current.symbol() == Symbol.OPEN_PAREN) {
+            nextSymbol(true);
+            var expression = simpleExpression();
+            expectSymbol(Symbol.CLOSED_PAREN);
+            return expression;
+        } else {
+            throw new ExpressionParseException(
+                    "Expected to find a number or variable, but found " + current.symbol().name().toLowerCase()
+            );
+        }
+    }
+
+    private void nextSymbol(boolean force) throws ExpressionParseException {
+        if (tokens.hasNext()) {
+            current = tokens.next();
+        } else {
+            if (force) {
+                throw new ExpressionParseException(
+                        "Expected to find an expression after " + current.symbol().name().toLowerCase()
+                );
+            } else {
+                current = null;
+            }
+        }
+    }
+
+    private void expectSymbol(Symbol symbol) throws ExpressionParseException {
+        if (current.symbol() == symbol) {
+            nextSymbol(false);
+        } else {
+            throw new ExpressionParseException("Expected to find symbol " + symbol.name().toLowerCase());
+        }
+    }
+
+    public double getLiteral(Token token) throws ExpressionParseException {
+        var literalAsString = tokens.substringForToken(token);
+        try {
+            return Double.parseDouble(literalAsString);
+        } catch (NumberFormatException e) {
+            throw new ExpressionParseException(e);
+        }
+    }
+
+}

--- a/src/main/java/de/schottky/expression/Modifier.java
+++ b/src/main/java/de/schottky/expression/Modifier.java
@@ -1,0 +1,71 @@
+package de.schottky.expression;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+
+public interface Modifier {
+
+    static Modifier parse(String source) throws ExpressionParseException {
+        return new ExpressionParser(source).parse().simplify();
+    }
+
+    @Contract(" -> new")
+    static @NotNull Modifier noop() {
+        return new Simple(0);
+    }
+
+    double next(double previous, int level);
+
+    default Modifier simplify() {
+        return this;
+    }
+
+    record Enumeration(double[] enumeration) implements Modifier {
+
+        @Override
+        public double next(double previous, int level) {
+            // TODO: what happens if the enumeration contains less elements?
+            // idea: interpolation
+            return enumeration[level];
+        }
+    }
+
+    record Simple(double amountPerLevel) implements Modifier {
+
+        @Override
+        public double next(double previous, int level) {
+            return previous + amountPerLevel;
+        }
+    }
+
+    record Calculated(Expression expression) implements Modifier {
+
+        @Override
+        public double next(double previous, int level) {
+            return expression.evaluate(previous, level);
+        }
+
+        public Optional<Modifier> simplifyToSimpleModifier() {
+            if (expression.root() instanceof Expression.Node.Literal literal) {
+                var amount = literal.value();
+                return Optional.of(new Simple(amount));
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        @Contract(" -> new")
+        @Override
+        public @NotNull Modifier simplify() {
+            var simpleExpression = expression.simplify();
+            if (simpleExpression.root() instanceof Expression.Node.Literal literal) {
+                var amount = literal.value();
+                return new Simple(amount);
+            } else {
+                return new Calculated(simpleExpression);
+            }
+        }
+    }
+}

--- a/src/main/java/de/schottky/util/AttributeUtil.java
+++ b/src/main/java/de/schottky/util/AttributeUtil.java
@@ -2,6 +2,7 @@ package de.schottky.util;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import de.schottky.expression.Modifier;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.inventory.ItemStack;
@@ -22,9 +23,10 @@ public class AttributeUtil {
     public static void increaseAttribute(
             @NotNull ItemStack stack,
             Attribute attribute,
-            double byValue,
-            AttributeModifier ifAbsent)
-    {
+            Modifier byValue,
+            int level,
+            AttributeModifier ifAbsent
+    ) {
         final ItemMeta meta = stack.getItemMeta();
         if (meta == null) return;
 
@@ -37,7 +39,7 @@ public class AttributeUtil {
                 final AttributeModifier newModifier = new AttributeModifier(
                         modifier.getUniqueId(),
                         modifier.getName(),
-                        modifier.getAmount() + byValue,
+                        byValue.next(modifier.getAmount(), level),
                         modifier.getOperation(),
                         modifier.getSlot()
                 );

--- a/src/main/java/de/schottky/util/ConfigUtil.java
+++ b/src/main/java/de/schottky/util/ConfigUtil.java
@@ -2,25 +2,56 @@ package de.schottky.util;
 
 import com.github.schottky.zener.messaging.Console;
 import de.schottky.exception.InvalidConfiguration;
+import de.schottky.expression.ExpressionParseException;
+import de.schottky.expression.Modifier;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.EnumSet;
-import java.util.List;
+import java.util.*;
 import java.util.Objects;
-import java.util.Set;
 
 public class ConfigUtil {
 
     public static double getRequiredDouble(
             @NotNull ConfigurationSection section,
-            String name) throws InvalidConfiguration
-    {
+            String name
+    ) throws InvalidConfiguration {
         if (section.contains(name) && section.isDouble(name)) {
             return section.getDouble(name);
         } else {
             throw InvalidConfiguration.required(name);
+        }
+    }
+
+    @Contract("_, _ -> new")
+    public static @NotNull Modifier getRequiredModifier(
+            @NotNull ConfigurationSection section,
+            String name
+    ) throws InvalidConfiguration {
+        return getModifier(section, name).orElseThrow(() -> InvalidConfiguration.required(name));
+    }
+
+    public static Optional<Modifier> getModifier(
+            @NotNull ConfigurationSection section,
+            String name
+    ) throws InvalidConfiguration {
+        if (section.isDouble(name)) {
+            return Optional.of(
+                    new Modifier.Simple(section.getDouble(name))
+            );
+        } else if (section.isString(name)) {
+            try {
+                return Optional.of(
+                        Modifier.parse(section.getString(name))
+                );
+            } catch (ExpressionParseException e) {
+                throw InvalidConfiguration.parsingFailed(e, name);
+            }
+        } else {
+            return Optional.empty();
         }
     }
 

--- a/src/test/java/de/schottky/expression/ExpressionParserTests.java
+++ b/src/test/java/de/schottky/expression/ExpressionParserTests.java
@@ -1,0 +1,185 @@
+package de.schottky.expression;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.schottky.expression.Expression.Node;
+import de.schottky.expression.Expression.Node.Variable.Kind;
+import de.schottky.expression.Expression.Node.Literal;
+import de.schottky.expression.Expression.Node.Variable;
+import de.schottky.expression.Expression.Node.Operation;
+import de.schottky.expression.Expression.Node.Operation.Type;
+
+public class ExpressionParserTests {
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "  ", "\t", " \n\t" })
+    void the_expression_parser_throws_when_empty(String toParse) {
+        assertThrows(ExpressionParseException.class, () -> new ExpressionParser(toParse).parse());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "[]", "[  ]", "[ \n]", "[", "[  " })
+    void it_parses_an_empty_enumeration(String toParse) throws Exception {
+        var parser = new ExpressionParser(toParse);
+        var modifier = parser.parse();
+        assertEquals(modifier.getClass(), Modifier.Enumeration.class);
+        assertArrayEquals(((Modifier.Enumeration) modifier).enumeration(), new double[0]);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(FullArrayArgumentsSource.class)
+    void it_parses_an_array_with_contents(String toParse, double[] contents) throws Exception {
+        var parser = new ExpressionParser(toParse);
+        var modifier = parser.parse();
+        assertEquals(modifier.getClass(), Modifier.Enumeration.class);
+        assertArrayEquals(((Modifier.Enumeration) modifier).enumeration(), contents);
+    }
+
+    static class FullArrayArgumentsSource implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("[1]", new double[] { 1 }),
+                    Arguments.of("[1 2]", new double[] { 1, 2 }),
+                    Arguments.of("[  1.5]", new double[] { 1.5 }),
+                    Arguments.of("[  1 5", new double[] { 1, 5 }),
+                    Arguments.of("[1  5]", new double[] { 1, 5 }),
+                    Arguments.of("[1.0 .1]", new double[] { 1.0, 0.1 })
+            );
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "[[1]", "[1, 2]", "[xy]", "[a+b]", "[f" })
+    void it_throws_on_illegal_combinations(String stringToParse) {
+        var parser = new ExpressionParser(stringToParse);
+        assertThrows(ExpressionParseException.class, parser::parse);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "[1.1. ]", "[ 1.ee ]", "[ 1,5 ]" })
+    void it_throws_when_there_is_an_illegal_number(String stringToParse) {
+        var parser = new ExpressionParser(stringToParse);
+        assertThrows(ExpressionParseException.class, parser::parse);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(value = TermArgumentsProvider.class)
+    @ArgumentsSource(SimpleExpressionArgumentsProvider.class)
+    @ArgumentsSource(FactorArgumentsProvider.class)
+    void it_parses_expressions(String stringToParse, Expression.Node expected) throws Exception {
+        var modifier = new ExpressionParser(stringToParse).parse();
+        if (expected instanceof Literal literal) {
+            assertEquals(Modifier.Simple.class, modifier.getClass());
+            assertEquals(literal.value(), ((Modifier.Simple) modifier).amountPerLevel());
+        } else {
+            assertEquals(Modifier.Calculated.class, modifier.getClass());
+            var root = ((Modifier.Calculated) modifier).expression().root();
+            assertEquals(expected, root);
+        }
+    }
+
+    static class FactorArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("1", new Literal(1)),
+                    Arguments.of("1.2", new Literal(1.2)),
+                    Arguments.of("lvl", new Variable(Kind.LEVEL)),
+                    Arguments.of("lEvEl", new Variable(Kind.LEVEL)),
+                    Arguments.of("prev", new Variable(Kind.PREVIOUS)),
+                    Arguments.of("pReViOUs", new Variable(Kind.PREVIOUS))
+            );
+        }
+    }
+
+    static class TermArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("2 * lvl", new Operation(
+                            Type.MULTIPLICATION,
+                            new Literal(2),
+                            new Variable(Kind.LEVEL)
+                    )),
+                    Arguments.of("prev%lvl", new Operation(
+                            Type.MODULUS,
+                            new Variable(Kind.PREVIOUS),
+                            new Variable(Kind.LEVEL)
+                    ))
+            );
+        }
+    }
+
+    static class SimpleExpressionArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("2 + lvl", new Operation(
+                            Type.ADDITION,
+                            new Literal(2),
+                            new Variable(Kind.LEVEL)
+                    )),
+                    Arguments.of("2 + lvl * 3", new Operation(
+                            Type.ADDITION,
+                            new Literal(2),
+                            new Operation(
+                                    Type.MULTIPLICATION,
+                                    new Variable(Kind.LEVEL),
+                                    new Literal(3)
+                            )
+                    )),
+                    Arguments.of("-2", new Operation(
+                            Type.MULTIPLICATION,
+                            new Literal(-1),
+                            new Literal(2)
+                    )),
+                    Arguments.of("2 * lvl + 3", new Operation(
+                            Type.ADDITION,
+                            new Operation(
+                                    Type.MULTIPLICATION,
+                                    new Literal(2),
+                                    new Variable(Kind.LEVEL)
+                            ),
+                            new Literal(3)
+                    )),
+                    Arguments.of("2*3-3/2", new Operation(
+                            Type.SUBTRACTION,
+                            Node.operation(Type.MULTIPLICATION, 2, 3),
+                            Node.operation(Type.DIVISION, 3, 2)
+                    ))
+            );
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ComplexExpressionsArgumentsProvider.class)
+    void it_computes_the_correct_result_for_complex_expressions(String stringToParse, double previous, int level, double expected) throws Exception {
+        var expression = new ExpressionParser(stringToParse).parse();
+        var result = expression.next(previous, level);
+        assertEquals(expected, result);
+    }
+
+    static class ComplexExpressionsArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("(2 * 2 * prev + 4) * 5", 3, -1, 80),
+                    Arguments.of("(2 * 2 * prev + 4) * 5", 2.5, -1, 70),
+                    Arguments.of("(2 * 2 * prev + 4) * 5", 7, -1, 160),
+                    Arguments.of("5 * lvl + 2 * (3 + lvl) + prev", 2, 2, 22)
+            );
+        }
+    }
+}

--- a/src/test/java/de/schottky/expression/ExpressionTests.java
+++ b/src/test/java/de/schottky/expression/ExpressionTests.java
@@ -1,0 +1,86 @@
+package de.schottky.expression;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExpressionTests {
+
+    @Test
+    void A_literal_node_evaluates_to_its_literal_value() {
+        var testNode = new Expression.Node.Literal(5);
+        assertEquals(testNode.evaluate(10, 10), 5);
+    }
+
+    @Test
+    void A_variable_node_evaluates_to_level_or_previous() {
+        var testNode = new Expression.Node.Variable(Expression.Node.Variable.Kind.LEVEL);
+        assertEquals(testNode.evaluate(10, 2), 2);
+        testNode = new Expression.Node.Variable(Expression.Node.Variable.Kind.PREVIOUS);
+        assertEquals(testNode.evaluate(10, 2), 10);
+    }
+
+    @Test
+    void An_operation_node_evaluates_to_the_result_of_its_children() {
+        var testLeftNode = new Expression.Node.Literal(3);
+        var testRightNode = new Expression.Node.Literal(5);
+        var testNode = new Expression.Node.Operation(
+                Expression.Node.Operation.Type.ADDITION,
+                testRightNode,
+                testLeftNode
+        );
+        assertEquals(testNode.evaluate(0, 0), 8);
+    }
+
+    @Test
+    void the_result_of_an_operation_is_the_expected_result() {
+        assertEquals(
+                Expression.Node.Operation.Type.MULTIPLICATION.apply(9.5, 8.5),
+                9.5 * 8.5
+        );
+        assertEquals(
+                Expression.Node.Operation.Type.ADDITION.apply(3.6, 9.8),
+                3.6 + 9.8
+        );
+        assertEquals(
+                Expression.Node.Operation.Type.SUBTRACTION.apply(5, 77.7),
+                5 - 77.7
+        );
+        assertEquals(
+                Expression.Node.Operation.Type.DIVISION.apply(8, 4),
+                8.0 / 4
+        );
+    }
+
+    @Test
+    void An_operation_node_evaluates_correctly_nested() {
+        var leftNested = new Expression.Node.Literal(4);
+        var rightNested = new Expression.Node.Literal(6);
+        var nestedExpression = new Expression.Node.Operation(
+                Expression.Node.Operation.Type.ADDITION,
+                leftNested,
+                rightNested
+        );
+        var rightActual = new Expression.Node.Variable(Expression.Node.Variable.Kind.PREVIOUS);
+        var testNode = new Expression.Node.Operation(
+                Expression.Node.Operation.Type.MULTIPLICATION,
+                nestedExpression,
+                rightActual
+        );
+        // result should be (4 + 6) * previous
+        assertEquals(testNode.evaluate(2, 0), 20);
+    }
+
+    @Test
+    void an_expression_can_be_simplified_with_constants() {
+        var left = new Expression.Node.Literal(4);
+        var right = new Expression.Node.Literal(4);
+        var operation = new Expression.Node.Operation(
+                Expression.Node.Operation.Type.ADDITION,
+                left,
+                right
+        );
+        var expression = new Expression(operation);
+        assertEquals(new Expression.Node.Literal(8), expression.simplify().root());
+    }
+}

--- a/src/test/java/de/schottky/expression/LexerTests.java
+++ b/src/test/java/de/schottky/expression/LexerTests.java
@@ -1,0 +1,88 @@
+package de.schottky.expression;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.schottky.expression.ExpressionLexer.Token;
+import de.schottky.expression.ExpressionLexer.Symbol;
+
+public class LexerTests {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "  ", "\t", "\n", "\n  ", "\n\t  "})
+    void the_lexer_has_no_token_when_the_string_is_empty(String source) {
+        var lexer = new ExpressionLexer(source);
+        assertFalse(lexer.hasNext());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SingleTokenArgumentsProvider.class)
+    void the_lexer_parses_a_single_token(String source, Token expected) {
+        var lexer = new ExpressionLexer(source);
+        assertTrue(lexer.hasNext());
+        var next = lexer.next();
+        assertEquals(next, expected);
+    }
+
+    static class SingleTokenArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("+", Symbol.PLUS.toToken(0, 1)),
+                    Arguments.of("-", Symbol.MINUS.toToken(0, 1)),
+                    Arguments.of("bla", Symbol.VARIABLE.toToken(0, 3)),
+                    Arguments.of("12", Symbol.LITERAL.toToken(0, 2)),
+                    Arguments.of("1.2", Symbol.LITERAL.toToken(0, 3)),
+                    Arguments.of("##", Symbol.UNKNOWN.toToken(0, 2))
+            );
+        }
+    }
+
+    @Test
+    void the_lexer_parses_a_single_token_with_surrounding_whitespaces() {
+        var lexer = new ExpressionLexer("  Hello  \n");
+        assertTrue(lexer.hasNext());
+        assertEquals(lexer.next(), Symbol.VARIABLE.toToken(2, 5));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(MultipleTokensArgumentsProvider.class)
+    void the_lexer_parses_multiple_tokens(String toParse, Iterable<Token> expected) {
+        var tokens = ExpressionLexer.iterateTokensIn(toParse);
+        assertIterableEquals(expected, tokens);
+    }
+
+    static class MultipleTokensArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("1 2", List.of(
+                            Symbol.LITERAL.toToken(0, 1),
+                            Symbol.LITERAL.toToken(2, 1)
+                    )),
+                    Arguments.of(" 1 + 1", List.of(
+                            Symbol.LITERAL.toToken(1, 1),
+                            Symbol.PLUS.toToken(3, 1),
+                            Symbol.LITERAL.toToken(5, 1)
+                    )),
+                    Arguments.of("2*level", List.of(
+                            Symbol.LITERAL.toToken(0, 1),
+                            Symbol.MULTIPLY.toToken(1, 1),
+                            Symbol.VARIABLE.toToken(2, 5)
+                    ))
+            );
+        }
+    }
+}

--- a/src/test/java/de/schottky/expression/ModifierTests.java
+++ b/src/test/java/de/schottky/expression/ModifierTests.java
@@ -1,0 +1,95 @@
+package de.schottky.expression;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ModifierTests {
+
+    private void testModifier(Modifier modifier, double @NotNull [] expectedPerLevel, double startPrevious) {
+        var previous = startPrevious;
+        for (int level = 0; level < expectedPerLevel.length; ++level) {
+            var next = modifier.next(previous, level);
+            assertEquals(expectedPerLevel[level], next, 1e-8);
+            previous = next;
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SimpleModifierArgumentsSource.class)
+    void a_simple_modifier_increases_linearly_with_the_level(String rawModifer, double @NotNull [] perLevel) throws Exception {
+        var modifier = Modifier.parse(rawModifer);
+        assertEquals(Modifier.Simple.class, modifier.getClass());
+        testModifier(modifier, perLevel, 0);
+    }
+
+    static class SimpleModifierArgumentsSource implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("0", new double[] { 0, 0, 0 }),
+                    Arguments.of("1", new double[] { 1, 2, 3 }),
+                    Arguments.of("3", new double[] { 3, 6, 9 }),
+                    Arguments.of("1 + 1", new double[] { 2, 4, 6 }),
+                    // can be folded into a single argument
+                    Arguments.of("(2 + 0) * 1 -3+2", new double[] { 1, 2, 3 })
+            );
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(EnumerationArgumentsSource.class)
+    void an_enumeration_retains_the_value_when_parsed(String rawModifier, double @NotNull [] perLevel) throws Exception {
+        var modifier = Modifier.parse(rawModifier);
+        assertEquals(Modifier.Enumeration.class, modifier.getClass());
+        testModifier(modifier, perLevel, 0);
+    }
+
+    static class EnumerationArgumentsSource implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("[0 0 0]", new double[] { 0, 0, 0 }),
+                    Arguments.of("[1 2 3]", new double[] { 1, 2, 3 }),
+                    Arguments.of("[1.2 1.8 2.0", new double[] { 1.2, 1.8, 2.0 })
+            );
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(CalculatedArgumentsSource.class)
+    void a_calculated_expression_computes_the_correct_value_per_level(
+            String rawModifier,
+            double @NotNull [] perLevel,
+            double startPrevious
+    ) throws Exception {
+        var modifier = Modifier.parse(rawModifier);
+        assertEquals(Modifier.Calculated.class, modifier.getClass());
+        testModifier(modifier, perLevel, startPrevious);
+    }
+
+    static class CalculatedArgumentsSource implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("2*lvl", new double[] { 0, 2, 4 }, 0),
+                    Arguments.of("prev + 1", new double[] { 1, 2, 3 }, 0),
+                    Arguments.of("prev + lvl", new double[] { 0, 1, 3 }, 0),
+                    Arguments.of("lvl + 1", new double[] { 1, 2, 3 }, 0),
+                    Arguments.of("(lvl + 1) * 2", new double[] { 2, 4, 6 }, 0),
+                    Arguments.of("(lvl + 1) * 1.5", new double[] { 1.5, 3, 4.5 }, 0),
+                    Arguments.of("prev * 1.1", new double[] { 1.1, 1.21, 1.331 }, 1)
+            );
+        }
+    }
+}


### PR DESCRIPTION
Introduce modifiers that enhance how the new value for armor / damage, e.t.c is calculated. A modifier can be

- A simple value i.e. `armorModifier: 1.0` - which means 1.0 amount of something per level  
- A list i.e. `armorModifier: "[1 2 3]"` - which means 1 on the first level, 2 on the second level, e.t.c
- A (complex) expression with variables i.e. `armorModifier: "2 * (lvl + 1)"` - which means 4 on the first level, 6 on the second level, e.t.c.